### PR TITLE
Meld takes an operand

### DIFF
--- a/lib/pairing_heap.ex
+++ b/lib/pairing_heap.ex
@@ -80,6 +80,11 @@ end
   iex> PairingHeap.meld(heap0, heap1)
   {1, "smallest", [{2, "biggest", []}]}
 
+  iex> heap0 = PairingHeap.new(1, "smallest")
+  iex> heap1 = PairingHeap.new(2, "biggest")
+  iex> PairingHeap.meld(heap0, heap1, :>)
+  {2, "biggest", [{1, "smallest", []}]}
+
   """
   @spec meld(t, t) :: t
   def meld(nil, heap), do: heap
@@ -90,9 +95,9 @@ end
   # defp meld(l, _r = {key_r, value_r, sub_r}) do
   #   {key_r, value_r, [l | sub_r]}
   # end
-  def meld(l = {key_l, value_l, sub_l}, r = {key_r, value_r, sub_r}) do
+  def meld(l = {key_l, value_l, sub_l}, r = {key_r, value_r, sub_r}, comparison \\ :<) do
     cond do
-      key_l < key_r -> {key_l, value_l, [r | sub_l]}
+      apply(Kernel, comparison, [key_l, key_r]) -> {key_l, value_l, [r | sub_l]}
       true          -> {key_r, value_r, [l | sub_r]}
     end
   end

--- a/lib/pairing_heap.ex
+++ b/lib/pairing_heap.ex
@@ -84,7 +84,6 @@ end
   iex> heap1 = PairingHeap.new(2, "biggest")
   iex> PairingHeap.meld(heap0, heap1, :>)
   {2, "biggest", [{1, "smallest", []}]}
-
   """
   @spec meld(t, t) :: t
   def meld(nil, heap), do: heap
@@ -104,9 +103,21 @@ end
 
   @doc """
   Merge (meld) two heaps
+
+  iex> heap0 = PairingHeap.new(1, "smallest")
+  iex> heap1 = PairingHeap.new(2, "biggest")
+  iex> PairingHeap.merge(heap0, heap1)
+  {1, "smallest", [{2, "biggest", []}]}
+
+  iex> heap0 = PairingHeap.new(1, "smallest")
+  iex> heap1 = PairingHeap.new(2, "biggest")
+  iex> PairingHeap.merge(heap0, heap1, :>)
+  {2, "biggest", [{1, "smallest", []}]}
   """
   @spec merge(t, t) :: t
+  # TODO - add typespec for merge/3
   def merge(h1, h2), do: meld(h1, h2)
+  def merge(h1, h2, comparison), do: meld(h1, h2, comparison)
 
   @doc """
   min item in the heap

--- a/lib/pairing_heap.ex
+++ b/lib/pairing_heap.ex
@@ -74,6 +74,12 @@ end
 
   @doc """
   Merge (meld) two heaps
+
+  iex> heap0 = PairingHeap.new(1, "smallest")
+  iex> heap1 = PairingHeap.new(2, "biggest")
+  iex> PairingHeap.meld(heap0, heap1)
+  {1, "smallest", [{2, "biggest", []}]}
+
   """
   @spec meld(t, t) :: t
   def meld(nil, heap), do: heap

--- a/lib/priority_queue.ex
+++ b/lib/priority_queue.ex
@@ -148,6 +148,9 @@ end
 
   @doc """
   Returns new, empty priority queue
+
+  iex> PriorityQueue.new
+  %PriorityQueue{heap: nil, size: 0}
   """
   def new, do: %__MODULE__{}
 


### PR DESCRIPTION
Possible way to move toward [providing a max heap implementation](https://github.com/ewildgoose/elixir_priority_queue/issues/1). 

I'm not actually sure if this is a good idea. Passing around the comparison seems like it may get unwieldy. An alternate idea would be to have another module that does `use PairingHeap` and have `PairingHeap` declare `defoverridable [meld: 2]`
