### PR TITLE
feat: compatibility updates with 1.15/otp-26

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+# and its dependencies with the aid of the Config module.
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/pairing_heap.ex
+++ b/lib/pairing_heap.ex
@@ -1,9 +1,8 @@
 defmodule PairingHeap do
-
-if Application.get_env(:priority_queue, :native) do
-  @compile :native
-  @compile {:hipe, [:o3]}
-end
+  if Application.compile_env(:priority_queue, :native) do
+    @compile :native
+    @compile {:hipe, [:o3]}
+  end
 
   @moduledoc """
   Pairing Heap implementation
@@ -114,10 +113,8 @@ end
   def new(), do: nil
   def new(key, value), do: {key, value, []}
 
-  @doc """
-  Pairing Heaps get their name from the special "pair" operation, which is used to
-  'Pair up' (recursively meld) a list of pairing heaps.
-  """
+  # Pairing Heaps get their name from the special "pair" operation, which is used to
+  # 'Pair up' (recursively meld) a list of pairing heaps.
   @spec pair([t]) :: t
   defp pair([]), do: nil
   defp pair([h]), do: h

--- a/lib/priority_queue.ex
+++ b/lib/priority_queue.ex
@@ -1,10 +1,8 @@
 defmodule PriorityQueue do
-
-if Application.get_env(:priority_queue, :native) do
-  @compile :native
-  @compile {:hipe, [:o3]}
-end
-
+  if Application.compile_env(:priority_queue, :native) do
+    @compile :native
+    @compile {:hipe, [:o3]}
+  end
 
   @moduledoc """
   Priority Queues in Elixir

--- a/mix.exs
+++ b/mix.exs
@@ -8,9 +8,9 @@ defmodule PriorityQueue.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      description: "Priority Queue for Elixir. Heap implementation",
-     package: package,
+     package: package(),
      source_url: "https://github.com/ewildgoose/elixir_priority_queue",
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
Calling functions with no parens is now a compilation error. There are flags you can set for backward compatibility, but () were added in mix.exs (deps and package function calls).

Fixed additional warnings on using get_env vs. compile_env.

Fixed additional warning about @doc on a private method.